### PR TITLE
Fixing protobuf undefined symbols related to protobuf on vxworks

### DIFF
--- a/src/google/protobuf/stubs/platform_macros.h
+++ b/src/google/protobuf/stubs/platform_macros.h
@@ -118,7 +118,7 @@ GOOGLE_PROTOBUF_PLATFORM_ERROR
 
 #undef GOOGLE_PROTOBUF_PLATFORM_ERROR
 
-#if defined(GOOGLE_PROTOBUF_OS_ANDROID) || defined(GOOGLE_PROTOBUF_OS_IPHONE) || defined(__OpenBSD__)
+#if defined(GOOGLE_PROTOBUF_OS_ANDROID) || defined(GOOGLE_PROTOBUF_OS_IPHONE) || defined(__OpenBSD__) || defined(__VXWORKS__)
 // Android ndk does not support the __thread keyword very well yet. Here
 // we use pthread_key_create()/pthread_getspecific()/... methods for
 // TLS support on android.

--- a/src/google/protobuf/wire_format.cc
+++ b/src/google/protobuf/wire_format.cc
@@ -916,7 +916,7 @@ uint8* WireFormat::InternalSerializeField(const FieldDescriptor* field,
       HANDLE_PRIMITIVE_TYPE(SINT64, int64, SInt64, Int64)
       HANDLE_PRIMITIVE_TYPE(UINT32, uint32, UInt32, UInt32)
       HANDLE_PRIMITIVE_TYPE(UINT64, uint64, UInt64, UInt64)
-      HANDLE_PRIMITIVE_TYPE(ENUM, int, Enum, Enum)
+      HANDLE_PRIMITIVE_TYPE(ENUM, int32, Enum, Enum)
 
 #undef HANDLE_PRIMITIVE_TYPE
 #define HANDLE_PRIMITIVE_TYPE(TYPE, CPPTYPE, TYPE_METHOD, CPPTYPE_METHOD)   \


### PR DESCRIPTION
This commit contains two changes: 
* Disable use of Thread-Local Storage on VxWorks
* Fix for https://github.com/protocolbuffers/protobuf/issues/7248 